### PR TITLE
feat!: metadata with custom NTP timestamp

### DIFF
--- a/lib/PlaybackArea.tsx
+++ b/lib/PlaybackArea.tsx
@@ -2,9 +2,10 @@ import React, { Ref } from 'react'
 import { Sdp } from 'media-stream-library/lib/utils/protocols/sdp'
 
 import { PlayerNativeElement } from './Player'
-import { WsRtspVideo, MetadataMessage } from './WsRtspVideo'
+import { WsRtspVideo } from './WsRtspVideo'
 import { WsRtspCanvas } from './WsRtspCanvas'
 import { StillImage } from './StillImage'
+import { MetadataHandler } from './metadata'
 
 export const AXIS_IMAGE_CGI = 'jpg'
 const AXIS_VIDEO_CGI = 'mjpg'
@@ -33,7 +34,7 @@ interface PlaybackAreaProps {
   refresh: number
   onPlaying: (properties: VideoProperties) => void
   onSdp?: (msg: Sdp) => void
-  metadataHandler?: (msg: MetadataMessage) => void
+  metadataHandler?: MetadataHandler
 }
 
 const API_TYPES = new Set([AXIS_IMAGE_CGI, AXIS_VIDEO_CGI, AXIS_MEDIA_AMP])

--- a/lib/Player.tsx
+++ b/lib/Player.tsx
@@ -11,9 +11,9 @@ import {
 import { Controls } from './Controls'
 import { Feedback } from './Feedback'
 import { Sdp } from 'media-stream-library/dist/esm/utils/protocols'
-import { MetadataMessage } from './WsRtspVideo'
 import { Stats } from './Stats'
 import { useSwitch } from './hooks/useSwitch'
+import { MetadataHandler } from './metadata'
 
 const DEFAULT_API_TYPE = AXIS_IMAGE_CGI
 
@@ -23,7 +23,7 @@ interface PlayerProps {
   format?: Format
   autoPlay?: boolean
   onSdp?: (msg: Sdp) => void
-  metadataHandler?: (msg: MetadataMessage) => void
+  metadataHandler?: MetadataHandler
   aspectRatio?: number
 }
 

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -1,0 +1,87 @@
+import {
+  MessageType,
+  XmlMessage,
+} from 'media-stream-library/dist/esm/components/message'
+
+import {
+  pipelines,
+  utils,
+  components,
+} from 'media-stream-library/dist/esm/index.browser'
+
+/**
+ * Metadata handlers
+ *
+ * For video streams that also include ONVIF metadata,
+ * once can specify a parser + synced callback to be run
+ * whenever metadata occurs on the stream.
+ *
+ * The `parser` provided produces a scheduled message, that
+ * will be returned later through the `cb` synched callback,
+ * whenever the message is synchronized with the presentation.
+ */
+export interface MetadataXMLMessage extends XmlMessage {
+  xmlDocument: XMLDocument
+}
+interface ScheduledMessage {
+  readonly ntpTimestamp: number | undefined
+  readonly data: unknown
+}
+export type MetadataParser = (msg: MetadataXMLMessage) => ScheduledMessage
+export type MetadataCallback = (msg: ScheduledMessage) => void
+export interface MetadataHandler {
+  /**
+   * A parser that will receive an XML message and should return
+   * a new message with at least an ntpTimestamp.
+   */
+  readonly parser: MetadataParser
+  /**
+   * A synchronized callback that will be called whenever the message
+   * produced by the parser is in sync with the video.
+   */
+  readonly cb: MetadataCallback
+}
+
+/**
+ * Attach ONVIF metadata handlers to a pipeline
+ *
+ * @param pipeline The (HTML5 video) pipeline to modify
+ * @param handlers The handlers to deal with XML data
+ */
+export const attachMetadataHandler = (
+  pipeline: pipelines.Html5VideoPipeline,
+  { parser, cb }: MetadataHandler,
+) => {
+  /**
+   * When a metadata handler is available on this component, it will be
+   * called in sync with the player, using a scheduler to synchronize the
+   * callback with the video presentation time.
+   */
+  const scheduler = new utils.Scheduler(pipeline, cb, 30)
+  const xmlParser = new DOMParser()
+
+  const xmlMessageHandler = (msg: XmlMessage) => {
+    const xmlDocument = xmlParser.parseFromString(
+      msg.data.toString(),
+      'text/xml',
+    )
+    const newMsg = parser({ ...msg, xmlDocument })
+    if (msg.ntpTimestamp) {
+      scheduler.run(newMsg)
+    }
+  }
+
+  // Add extra components to the pipeline.
+  const onvifDepay = new components.ONVIFDepay()
+  const onvifHandlerPipe = components.Tube.fromHandlers((msg) => {
+    if (msg.type === MessageType.XML) {
+      xmlMessageHandler(msg)
+    }
+  }, undefined)
+  pipeline.insertAfter(pipeline.rtsp, onvifDepay)
+  pipeline.insertAfter(onvifDepay, onvifHandlerPipe)
+
+  // Initialize the scheduler when presentation time is ready
+  pipeline.onSync = (ntpPresentationTime: number) =>
+    scheduler.init(ntpPresentationTime)
+}


### PR DESCRIPTION
The metadatahandler is split into a `parser` and `cb`
function. The former can modify the message that is sent
to the scheduler, so that custom NTP timestamps can be
used instead of those that are determined by the RTP
timestamp.

The `cb` is a synchonized callback that is run whenever
the parsed message is in sync with the video. This is
the former `metadataHandler` function.

BREAKING CHANGE: the optional `metadataHandler` property
has changed to an object {parser, cb} instead of a simple
function. If you use this property, consult the TypeScript
documentation for the new interface.