### PR TITLE
fix: Faulty CSS of webcomponent example

### DIFF
--- a/examples/web-component/index.html
+++ b/examples/web-component/index.html
@@ -5,6 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>media-stream-player</title>
     <script src="./media-stream-player.min.js"></script>
+    <style>
+      html {
+        height: 98vh;
+      }
+      body {
+        height: 98vh;
+      }
+      #root {
+        height: 98vh;
+      }
+    </style>
   </head>
 
   <body>


### PR DESCRIPTION
There is something wrong with the webcomponent example. The HTML, body and root elements doesn't get any height.

This is just a quick fix to rectify that issue and should be looked in to further when I have more time.

Fixes #31.

