### PR TITLE
feat: ability to set initial format for webcomponent

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 
 [ci-image]: https://github.com/AxisCommunications/media-stream-player-js/workflows/CI/badge.svg
 [ci-url]: https://github.com/AxisCommunications/media-stream-player-js/actions
-
 [npm-image]: https://img.shields.io/npm/v/media-stream-player.svg
 [npm-url]: https://www.npmjs.com/package/media-stream-player
 
@@ -42,6 +41,29 @@ Then, you can use the `<media-stream-player/>` tag, similar to how you would use
 ```
 
 You can find an example of this under `examples/web-component`.
+
+Supported properties right now are:
+
+- `hostname` - the ip address to your device
+- `autoplay` - if the property exists, we try to autoplay your video
+- `format` - accepted values are `JPEG`, `MJPEG` or `H264`
+
+Example:
+
+```html
+<media-stream-player hostname="192.168.0.90" format="H264" autoplay />
+```
+
+You may need to start a localhost server to get H264 and MJPEG video to run properly.
+It doesn't work with the `file:///` protocol. The easiest way to do that is Pythons simpleHttpServer.
+
+Go to the web-component example folder and type the following in you terminal:
+
+```bash
+python -m SimpleHTTPServer 8080
+```
+
+Then you can open up http://localhost:8080 to see the result.
 
 ### As part of your React application
 

--- a/examples/web-component/index.html
+++ b/examples/web-component/index.html
@@ -5,10 +5,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>media-stream-player</title>
     <script src="./media-stream-player.min.js"></script>
+    <style>
+      #root {
+        height: 98vh;
+      }
+    </style>
   </head>
 
   <body>
     <div id="root" />
-    <media-stream-player hostname="192.168.0.90" autoplay />
+    <media-stream-player hostname="192.168.0.90" format="JPEG" autoplay />
   </body>
 </html>

--- a/lib/Controls.tsx
+++ b/lib/Controls.tsx
@@ -42,6 +42,7 @@ interface ControlsProps {
   onStop: () => void
   onRefresh: () => void
   onScreenshot: () => void
+  format?: Format
   onFormat: (format: Format) => void
   onVapix: (key: string, value: string) => void
   labels?: {
@@ -64,6 +65,7 @@ export const Controls: React.FC<ControlsProps> = ({
   onStop,
   onRefresh,
   onScreenshot,
+  format,
   onFormat,
   onVapix,
   labels,
@@ -109,6 +111,7 @@ export const Controls: React.FC<ControlsProps> = ({
       {settings && (
         <Settings
           parameters={parameters}
+          format={format}
           onFormat={onFormat}
           onVapix={onVapix}
           showStatsOverlay={showStatsOverlay}

--- a/lib/MediaStreamPlayer.tsx
+++ b/lib/MediaStreamPlayer.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from 'react'
 import ReactDOM from 'react-dom'
-import { Player } from './Player'
+import { Format, Player } from './Player'
 
 interface InitialAttributes {
   readonly hostname: string
   readonly autoplay: boolean
+  readonly format: string
 }
 
 type SetStateType = React.Dispatch<React.SetStateAction<InitialAttributes>>
@@ -26,7 +27,7 @@ export class MediaStreamPlayer extends HTMLElement {
   }
 
   static get observedAttributes() {
-    return ['hostname', 'autoplay']
+    return ['hostname', 'autoplay', 'format']
   }
 
   get hostname() {
@@ -49,6 +50,14 @@ export class MediaStreamPlayer extends HTMLElement {
     }
   }
 
+  get format() {
+    return this.getAttribute('format') ?? 'JPEG'
+  }
+
+  set format(value: string) {
+    this.setAttribute('format', value)
+  }
+
   connectedCallback() {
     window
       .fetch(`http://${this.hostname}/axis-cgi/usergroup.cgi`, {
@@ -56,7 +65,7 @@ export class MediaStreamPlayer extends HTMLElement {
         mode: 'no-cors',
       })
       .then(() => {
-        const { hostname, autoplay } = this
+        const { hostname, autoplay, format } = this
 
         ReactDOM.render(
           <PlayerComponent
@@ -66,6 +75,7 @@ export class MediaStreamPlayer extends HTMLElement {
             initialAttributes={{
               hostname,
               autoplay,
+              format,
             }}
           />,
           this,
@@ -86,10 +96,11 @@ export class MediaStreamPlayer extends HTMLElement {
       return
     }
 
-    const { hostname, autoplay } = this
+    const { hostname, autoplay, format } = this
     this._setState({
       hostname,
       autoplay,
+      format,
     })
   }
 }
@@ -109,7 +120,9 @@ const PlayerComponent: React.FC<PlayerComponentProps> = ({
     subscribeAttributesChanged(setState)
   }, [subscribeAttributesChanged])
 
-  const { hostname, autoplay } = state
+  const { hostname, autoplay, format } = state
 
-  return <Player hostname={hostname} autoPlay={autoplay} />
+  return (
+    <Player hostname={hostname} autoPlay={autoplay} format={format as Format} />
+  )
 }

--- a/lib/Player.tsx
+++ b/lib/Player.tsx
@@ -96,9 +96,7 @@ export const Player = forwardRef<PlayerNativeElement, PlayerProps>(
     const [refresh, setRefresh] = useState(0)
     const [host, setHost] = useState(hostname)
     const [waiting, setWaiting] = useState(autoPlay)
-    const [api, setApi] = useState(
-      format ? FORMAT_API[format] : DEFAULT_API_TYPE,
-    )
+    const [api, setApi] = useState<string>(DEFAULT_API_TYPE)
 
     /**
      * VAPIX parameters
@@ -167,7 +165,7 @@ export const Player = forwardRef<PlayerNativeElement, PlayerProps>(
       setWaiting(false)
     }, [])
 
-    const onFormat = (format: Format) => {
+    const onFormat = useCallback((format: Format | undefined) => {
       switch (format) {
         case 'H264':
           setApi(AXIS_MEDIA_AMP)
@@ -178,13 +176,16 @@ export const Player = forwardRef<PlayerNativeElement, PlayerProps>(
           setParameters({ ...parameters, videocodec: 'jpeg' })
           break
         case 'JPEG':
+        default:
           setApi(AXIS_IMAGE_CGI)
           break
-        default:
-        // no-op
       }
       setRefresh((value) => value + 1)
-    }
+    }, [])
+
+    useEffect(() => {
+      onFormat(format)
+    }, [format])
 
     const onVapix = (key: string, value: string) => {
       setParameters((p: typeof vapixParams) => {
@@ -307,6 +308,7 @@ export const Player = forwardRef<PlayerNativeElement, PlayerProps>(
                 onStop={onStop}
                 onRefresh={onRefresh}
                 onScreenshot={onScreenshot}
+                format={format}
                 onFormat={onFormat}
                 onVapix={onVapix}
                 labels={{

--- a/lib/Settings.tsx
+++ b/lib/Settings.tsx
@@ -42,6 +42,7 @@ const SettingsItem = styled.div`
 
 interface SettingsProps {
   parameters: VapixParameters
+  format?: Format
   onFormat: (format: Format) => void
   onVapix: (key: string, value: string) => void
   showStatsOverlay: boolean
@@ -50,6 +51,7 @@ interface SettingsProps {
 
 export const Settings: React.FC<SettingsProps> = ({
   parameters,
+  format,
   onFormat,
   onVapix,
   showStatsOverlay,
@@ -83,6 +85,7 @@ export const Settings: React.FC<SettingsProps> = ({
           onChange={(e: ChangeEvent<HTMLSelectElement>) =>
             onFormat(e.target.value as Format)
           }
+          defaultValue={format}
         >
           <option value={'H264'}>H.264 over RTP</option>
           <option value={'MJPEG'}>JPEG over RTP</option>


### PR DESCRIPTION
- Ability to set initial format for webcomponent
- H264 is registered as H264, not MJPEG
- Format dropdown now initializes with correct format

Relates to #51.
Fixes #16.