### PR TITLE
fix: reset the scheduler on teardown

### DIFF
--- a/lib/WsRtspVideo.tsx
+++ b/lib/WsRtspVideo.tsx
@@ -3,11 +3,15 @@ import styled from 'styled-components'
 import debug from 'debug'
 
 import { Sdp } from 'media-stream-library/dist/esm/utils/protocols'
-import { pipelines } from 'media-stream-library/dist/esm/index.browser'
+import { pipelines, utils } from 'media-stream-library/dist/esm/index.browser'
 
 import useEventState from './hooks/useEventState'
 import { VideoProperties } from './PlaybackArea'
-import { attachMetadataHandler, MetadataHandler } from './metadata'
+import {
+  attachMetadataHandler,
+  MetadataHandler,
+  ScheduledMessage,
+} from './metadata'
 
 const debugLog = debug('msp:ws-rtsp-video')
 
@@ -122,14 +126,16 @@ export const WsRtspVideo: React.FC<WsRtspVideoProps> = ({
       })
       setPipeline(pipeline)
 
+      let scheduler: utils.Scheduler<ScheduledMessage> | undefined
       if (metadataHandler !== undefined) {
-        attachMetadataHandler(pipeline, metadataHandler)
+        scheduler = attachMetadataHandler(pipeline, metadataHandler)
       }
 
       return () => {
         debugLog('close pipeline and clear video')
         pipeline.close()
         videoEl.src = ''
+        scheduler?.reset()
         setPipeline(null)
         setFetching(false)
         unsetCanplay()

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -23,7 +23,7 @@ import {
 export interface MetadataXMLMessage extends XmlMessage {
   xmlDocument: XMLDocument
 }
-interface ScheduledMessage {
+export interface ScheduledMessage {
   readonly ntpTimestamp: number | undefined
   readonly data: unknown
 }
@@ -51,7 +51,7 @@ export interface MetadataHandler {
 export const attachMetadataHandler = (
   pipeline: pipelines.Html5VideoPipeline,
   { parser, cb }: MetadataHandler,
-) => {
+): utils.Scheduler<ScheduledMessage> => {
   /**
    * When a metadata handler is available on this component, it will be
    * called in sync with the player, using a scheduler to synchronize the
@@ -84,4 +84,6 @@ export const attachMetadataHandler = (
   // Initialize the scheduler when presentation time is ready
   pipeline.onSync = (ntpPresentationTime: number) =>
     scheduler.init(ntpPresentationTime)
+
+  return scheduler
 }


### PR DESCRIPTION
When the video element source is reset, the scheduler should also be
reset so that it doesn't trigger any unwanted scheduled events on the
video element.