### PR TITLE
feat: vapix parameters for web component

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,15 @@ You can find an example of this under `examples/web-component`.
 
 Supported properties right now are:
 
-- `hostname` - the ip address to your device
-- `autoplay` - if the property exists, we try to autoplay your video
-- `format` - accepted values are `JPEG`, `MJPEG` or `H264`
+| Property      | Comment                                                        |
+| ------------- | -------------------------------------------------------------- |
+| `hostname`    | The ip address to your device                                  |
+| `autoplay`    | If the property exists, we try and autoplay your video         |
+| `format`      | Accepted values are `JPEG`, `MJPEG` or `H264`                  |
+| `compression` | Accepted values are `0..100`, with 10 between each step        |
+| `resolution`  | Written as WidthXHeight, eg `1920x1080`                        |
+| `rotation`    | Accepted values are `0`, `90`, `180` and `270`                 |
+| `camera`      | Accepted values are `0...n` or `quad` depending on your device |
 
 Example:
 

--- a/examples/web-component/index.html
+++ b/examples/web-component/index.html
@@ -14,6 +14,14 @@
 
   <body>
     <div id="root" />
-    <media-stream-player hostname="192.168.0.90" format="JPEG" autoplay />
+    <media-stream-player
+      hostname="192.168.0.90"
+      format="JPEG"
+      compression="10"
+      resolution="1920x1080"
+      rotation="0"
+      camera="1"
+      autoplay
+    />
   </body>
 </html>

--- a/lib/MediaStreamPlayer.tsx
+++ b/lib/MediaStreamPlayer.tsx
@@ -1,11 +1,16 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useMemo } from 'react'
 import ReactDOM from 'react-dom'
+import { VapixParameters } from './PlaybackArea'
 import { Format, Player } from './Player'
 
 interface InitialAttributes {
   readonly hostname: string
   readonly autoplay: boolean
   readonly format: string
+  readonly compression: string
+  readonly resolution: string
+  readonly rotation: string
+  readonly camera: string
 }
 
 type SetStateType = React.Dispatch<React.SetStateAction<InitialAttributes>>
@@ -58,6 +63,38 @@ export class MediaStreamPlayer extends HTMLElement {
     this.setAttribute('format', value)
   }
 
+  public get compression() {
+    return this.getAttribute('compression') ?? ''
+  }
+
+  public set compression(value: string) {
+    this.setAttribute('compression', value)
+  }
+
+  public get resolution() {
+    return this.getAttribute('resolution') ?? ''
+  }
+
+  public set resolution(value: string) {
+    this.setAttribute('resolution', value)
+  }
+
+  public get rotation() {
+    return this.getAttribute('rotation') ?? ''
+  }
+
+  public set rotation(value: string) {
+    this.setAttribute('rotation', value)
+  }
+
+  public get camera() {
+    return this.getAttribute('camera') ?? ''
+  }
+
+  public set camera(value: string) {
+    this.setAttribute('camera', value)
+  }
+
   connectedCallback() {
     window
       .fetch(`http://${this.hostname}/axis-cgi/usergroup.cgi`, {
@@ -65,7 +102,15 @@ export class MediaStreamPlayer extends HTMLElement {
         mode: 'no-cors',
       })
       .then(() => {
-        const { hostname, autoplay, format } = this
+        const {
+          hostname,
+          autoplay,
+          format,
+          compression,
+          resolution,
+          rotation,
+          camera,
+        } = this
 
         ReactDOM.render(
           <PlayerComponent
@@ -76,6 +121,10 @@ export class MediaStreamPlayer extends HTMLElement {
               hostname,
               autoplay,
               format,
+              compression,
+              resolution,
+              rotation,
+              camera,
             }}
           />,
           this,
@@ -96,11 +145,24 @@ export class MediaStreamPlayer extends HTMLElement {
       return
     }
 
-    const { hostname, autoplay, format } = this
+    const {
+      hostname,
+      autoplay,
+      format,
+      compression,
+      resolution,
+      rotation,
+      camera,
+    } = this
+
     this._setState({
       hostname,
       autoplay,
       format,
+      compression,
+      resolution,
+      rotation,
+      camera,
     })
   }
 }
@@ -120,9 +182,44 @@ const PlayerComponent: React.FC<PlayerComponentProps> = ({
     subscribeAttributesChanged(setState)
   }, [subscribeAttributesChanged])
 
-  const { hostname, autoplay, format } = state
+  const {
+    hostname,
+    autoplay,
+    format,
+    compression,
+    resolution,
+    rotation,
+    camera,
+  } = state
+
+  const vapixParameters = useMemo(() => {
+    const params: VapixParameters = {}
+
+    if (compression !== '') {
+      params['compression'] = compression
+    }
+
+    if (resolution !== '') {
+      params['resolution'] = resolution
+    }
+
+    if (rotation !== '') {
+      params['rotation'] = rotation
+    }
+
+    if (camera !== '') {
+      params['camera'] = camera
+    }
+
+    return params
+  }, [compression, resolution, rotation, camera])
 
   return (
-    <Player hostname={hostname} autoPlay={autoplay} format={format as Format} />
+    <Player
+      hostname={hostname}
+      autoPlay={autoplay}
+      format={format as Format}
+      vapixParams={vapixParameters}
+    />
   )
 }


### PR DESCRIPTION
Added the possibility to specify certain vapix parameters in the web component.

Namely:

- compression
- resolution
- rotation
- camera

These are the vapix parameters that are in common between all three formats. There are plenty more we could support, but they will only work with a specific format.