### PR TITLE
feat: multi stream example

### DIFF
--- a/examples/react-app/App.jsx
+++ b/examples/react-app/App.jsx
@@ -2,102 +2,51 @@ import React, { useState, useCallback } from 'react'
 import styled, { createGlobalStyle } from 'styled-components'
 
 import { Player } from 'media-stream-player'
+import { SingleStream } from './SingleStream'
+import { MultiStream } from './MultiStream'
 
 const GlobalStyle = createGlobalStyle`
   body {
     margin: 0;
+    font-family: sans-serif;
   }
 `
 
-const AppContainer = styled.div`
-  width: 100vw;
-  height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+const ButtonContainer = styled.div`
+  margin: 8px;
+  text-align: center;
 `
 
-const HostnameContainer = styled.div`
-  align-items: center;
-  display: inline-grid;
-  grid-gap: 10px;
-  grid-template-columns: auto 1fr auto;
-  padding: 10px 0;
+const Button = styled.button`
+  padding: 8px 12px;
+  margin: 4px;
 `
 
-const MediaPlayer = styled(Player)`
-  width: 100%;
-  height: 100%;
-`
-
-const DEFAULT_HOSTNAME = '192.168.0.90'
-
-// force auth
-const authorize = async (host) => {
-  // Force a login by fetching usergroup
-  try {
-    await window.fetch(`http://${host}/axis-cgi/usergroup.cgi`, {
-      credentials: 'include',
-      mode: 'no-cors',
-    })
-  } catch (err) {
-    console.error(err)
-  }
-}
-
-/**
- * Example application that uses the `Player` component.
- */
+const LOCALSTORAGE_KEY = 'media-stream-player-example'
 
 export const App = () => {
-  const [state, setState] = useState({
-    authorized: false,
-    hostname: localStorage.getItem('hostname') || DEFAULT_HOSTNAME,
-  })
+  const example = localStorage.getItem(LOCALSTORAGE_KEY)
+  const [state, setState] = useState(example || 'single')
 
-  let vapixParams = {}
-  try {
-    vapixParams = JSON.parse(window.localStorage.getItem('vapix')) ?? {}
-  } catch (err) {
-    console.warn('no stored VAPIX parameters: ', err)
-  }
+  const single = useCallback(() => {
+    setState('single')
+    localStorage.setItem(LOCALSTORAGE_KEY, 'single')
+  }, [setState])
 
-  const connect = useCallback(() => {
-    if (!state.authorized) {
-      authorize(state.hostname).then(() => {
-        setState({ ...state, authorized: true })
-      })
-    }
-  }, [state.authorized, state.hostname])
+  const multi = useCallback(() => {
+    setState('multi')
+    localStorage.setItem(LOCALSTORAGE_KEY, 'multi')
+  }, [setState])
 
   return (
     <>
       <GlobalStyle />
-      <AppContainer>
-        <h1>media-stream-player</h1>
-        <HostnameContainer>
-          <label htmlFor="hostname">Hostname</label>
-          <input
-            id="hostname"
-            value={state.hostname}
-            onChange={({ target: { value } }) => {
-              setState({ authorized: false, hostname: value })
-              localStorage.setItem('hostname', value)
-            }}
-          />
-          <button onClick={connect}>connect</button>
-        </HostnameContainer>
-        {state.authorized ? (
-          <MediaPlayer
-            hostname={state.hostname}
-            format="H264"
-            autoPlay
-            vapixParams={vapixParams}
-          />
-        ) : (
-          <div>Not authorized</div>
-        )}
-      </AppContainer>
+      <ButtonContainer>
+        <Button onClick={single}>Single stream example</Button>
+        <Button onClick={multi}>Multi stream example</Button>
+      </ButtonContainer>
+      {state === 'single' ? <SingleStream /> : null}
+      {state === 'multi' ? <MultiStream /> : null}
     </>
   )
 }

--- a/examples/react-app/MultiStream.jsx
+++ b/examples/react-app/MultiStream.jsx
@@ -1,0 +1,113 @@
+import React, { useState, useEffect } from 'react'
+import styled from 'styled-components'
+
+import { Player } from 'media-stream-player'
+
+const Title = styled.h1`
+  text-align: center;
+  margin: 24px auto;
+`
+
+const AppContainer = styled.div`
+  width: 100vw;
+  height: 60vh;
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  justify-content: center;
+`
+const MediaPlayer = styled(Player)`
+  max-width: 400px;
+  max-height: 300px;
+  margin: 8px;
+`
+
+const MediaPlayerContainer = styled.div`
+  width: 400px;
+  height: 300px;
+  margin: 8px;
+`
+
+const Centered = styled.div`
+  text-align: center;
+`
+
+// force auth
+const authorize = async (host) => {
+  // Force a login by fetching usergroup
+  try {
+    await window.fetch(`http://${host}/axis-cgi/usergroup.cgi`, {
+      credentials: 'include',
+      mode: 'no-cors',
+    })
+  } catch (err) {
+    console.error(err)
+    throw err
+  }
+}
+
+/**
+ * Example multi stream application that uses the `Player` component.
+ */
+
+const devices = [
+  { hostname: '192.168.0.90', authorized: false },
+  { hostname: '192.168.0.91', authorized: false },
+  { hostname: '192.168.0.92', authorized: false },
+  { hostname: '192.168.0.93', authorized: false },
+  { hostname: '192.168.0.94', authorized: false },
+  { hostname: '192.168.0.95', authorized: false },
+]
+
+export const MultiStream = () => {
+  const [state, setState] = useState([])
+
+  useEffect(() => {
+    devices.forEach(({ hostname }) => {
+      authorize(hostname)
+        .then(() => {
+          setState((prevState) => [
+            ...prevState,
+            { hostname, authorized: true },
+          ])
+        })
+        .catch(() => {
+          setState((prevState) => [
+            ...prevState,
+            { hostname, authorized: false },
+          ])
+        })
+    })
+  }, [])
+
+  return (
+    <>
+      <Title>multi stream media-stream-player</Title>
+      <AppContainer>
+        {state.length > 0 ? (
+          state.map((device) => {
+            return device.authorized ? (
+              <MediaPlayerContainer key={device.hostname}>
+                <Centered>{device.hostname}</Centered>
+                <MediaPlayer
+                  hostname={device.hostname}
+                  format="JPEG"
+                  autoPlay
+                  vapixParams={{ resolution: '800x600' }}
+                />
+              </MediaPlayerContainer>
+            ) : (
+              <MediaPlayerContainer key={device.hostname}>
+                <Centered>{device.hostname}</Centered>
+                <Centered>Not authorized</Centered>
+              </MediaPlayerContainer>
+            )
+          })
+        ) : (
+          <div>No authorized devices</div>
+        )}
+      </AppContainer>
+    </>
+  )
+}

--- a/examples/react-app/SingleStream.jsx
+++ b/examples/react-app/SingleStream.jsx
@@ -1,0 +1,96 @@
+import React, { useState, useCallback } from 'react'
+import styled from 'styled-components'
+
+import { Player } from 'media-stream-player'
+
+const AppContainer = styled.div`
+  width: 100vw;
+  height: 90vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`
+
+const HostnameContainer = styled.div`
+  align-items: center;
+  display: inline-grid;
+  grid-gap: 10px;
+  grid-template-columns: auto 1fr auto;
+  padding: 10px 0;
+`
+
+const MediaPlayer = styled(Player)`
+  width: 100%;
+  height: 100%;
+`
+
+const DEFAULT_HOSTNAME = '192.168.0.90'
+
+// force auth
+const authorize = async (host) => {
+  // Force a login by fetching usergroup
+  try {
+    await window.fetch(`http://${host}/axis-cgi/usergroup.cgi`, {
+      credentials: 'include',
+      mode: 'no-cors',
+    })
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+/**
+ * Example application that uses the `Player` component.
+ */
+
+export const SingleStream = () => {
+  const [state, setState] = useState({
+    authorized: false,
+    hostname: localStorage.getItem('hostname') || DEFAULT_HOSTNAME,
+  })
+
+  let vapixParams = {}
+  try {
+    vapixParams = JSON.parse(window.localStorage.getItem('vapix')) ?? {}
+  } catch (err) {
+    console.warn('no stored VAPIX parameters: ', err)
+  }
+
+  const connect = useCallback(() => {
+    if (!state.authorized) {
+      authorize(state.hostname).then(() => {
+        setState({ ...state, authorized: true })
+      })
+    }
+  }, [state.authorized, state.hostname])
+
+  return (
+    <>
+      <AppContainer>
+        <h1>single stream media-stream-player</h1>
+        <HostnameContainer>
+          <label htmlFor="hostname">Hostname</label>
+          <input
+            id="hostname"
+            value={state.hostname}
+            onChange={({ target: { value } }) => {
+              setState({ authorized: false, hostname: value })
+              localStorage.setItem('hostname', value)
+            }}
+          />
+          <button onClick={connect}>connect</button>
+        </HostnameContainer>
+        {state.authorized ? (
+          <MediaPlayer
+            hostname={state.hostname}
+            format="H264"
+            autoPlay
+            vapixParams={vapixParams}
+          />
+        ) : (
+          <div>Not authorized</div>
+        )}
+      </AppContainer>
+    </>
+  )
+}


### PR DESCRIPTION
Added an example to show that you can use multiple players showing different streams in a single page.

Also refactored the example page to be able to switch between single stream and multi stream examples.

Preview:
![multistream1](https://user-images.githubusercontent.com/7765599/97288868-bba71a00-1846-11eb-9f06-389c517e7a7b.png)
