### PR TITLE
fix: debounce textstring updates

### DIFF
--- a/lib/Settings.tsx
+++ b/lib/Settings.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useCallback } from 'react'
+import React, { ChangeEvent, useCallback, useState } from 'react'
 import styled from 'styled-components'
 
 import { Format } from './Player'
@@ -57,10 +57,20 @@ export const Settings: React.FC<SettingsProps> = ({
   showStatsOverlay,
   toggleStats,
 }) => {
+  const [textString, setTextString] = useState(parameters['textstring'])
+  let textStringTimeout: number
+
   const changeParam = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     switch (e.target.name) {
       case 'textstring':
-        onVapix(e.target.name, e.target.value)
+        const { name, value } = e.target
+        setTextString(value)
+
+        clearTimeout(textStringTimeout)
+        textStringTimeout = window.setTimeout(() => {
+          onVapix(name, value)
+        }, 300)
+
         break
       case 'text':
         onVapix(e.target.name, e.target.checked ? '1' : '0')
@@ -148,11 +158,7 @@ export const Settings: React.FC<SettingsProps> = ({
       </SettingsItem>
       <SettingsItem>
         <div>Text overlay</div>
-        <input
-          name="textstring"
-          value={parameters['textstring']}
-          onChange={changeParam}
-        />
+        <input name="textstring" value={textString} onChange={changeParam} />
         <Switch
           name="text"
           checked={parameters['text'] === '1'}


### PR DESCRIPTION
When adding a text overlay to the camera through the settings there is an unnecessary amount of updates
for the video stream.

This fix introduces a 300 ms debounce before the text string is applied to the camera.

Before
![overlay_before](https://user-images.githubusercontent.com/7765599/97703560-1c398f80-1ab1-11eb-94cb-813ea9f51918.gif)

After
![overlay_after](https://user-images.githubusercontent.com/7765599/97703581-222f7080-1ab1-11eb-84e0-c82fb830ff42.gif)
