### PR TITLE
fix!: remember correct format

### DIFF
--- a/lib/Controls.tsx
+++ b/lib/Controls.tsx
@@ -42,7 +42,6 @@ interface ControlsProps {
   readonly onStop: () => void
   readonly onRefresh: () => void
   readonly onScreenshot: () => void
-  readonly format?: Format
   readonly onFormat: (format: Format) => void
   readonly onVapix: (key: string, value: string) => void
   readonly labels?: {
@@ -55,6 +54,7 @@ interface ControlsProps {
   }
   readonly showStatsOverlay: boolean
   readonly toggleStats: () => void
+  readonly api: string
 }
 
 export const Controls: React.FC<ControlsProps> = ({
@@ -65,12 +65,12 @@ export const Controls: React.FC<ControlsProps> = ({
   onStop,
   onRefresh,
   onScreenshot,
-  format,
   onFormat,
   onVapix,
   labels,
   showStatsOverlay,
   toggleStats,
+  api,
 }) => {
   const controlArea = useRef(null)
   const userActive = useUserActive(controlArea)
@@ -118,7 +118,7 @@ export const Controls: React.FC<ControlsProps> = ({
       {settings && (
         <Settings
           parameters={parameters}
-          format={format}
+          api={api}
           onFormat={onFormat}
           onVapix={onVapix}
           showStatsOverlay={showStatsOverlay}

--- a/lib/Player.tsx
+++ b/lib/Player.tsx
@@ -330,7 +330,6 @@ export const Player = forwardRef<PlayerNativeElement, PlayerProps>(
                 onStop={onStop}
                 onRefresh={onRefresh}
                 onScreenshot={onScreenshot}
-                format={format}
                 onFormat={onFormat}
                 onVapix={onVapix}
                 labels={{
@@ -343,6 +342,7 @@ export const Player = forwardRef<PlayerNativeElement, PlayerProps>(
                 }}
                 showStatsOverlay={showStatsOverlay}
                 toggleStats={toggleStatsOverlay}
+                api={api}
               />
             </Layer>
           </Container>

--- a/lib/Settings.tsx
+++ b/lib/Settings.tsx
@@ -1,8 +1,14 @@
-import React, { ChangeEventHandler, useCallback, useRef, useState } from 'react'
+import React, {
+  ChangeEventHandler,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import styled from 'styled-components'
 
 import { Format } from './Player'
-import { VapixParameters } from './PlaybackArea'
+import { AXIS_IMAGE_CGI, AXIS_MEDIA_AMP, VapixParameters } from './PlaybackArea'
 import { Switch } from './components/Switch'
 
 const SettingsMenu = styled.div`
@@ -42,7 +48,7 @@ const SettingsItem = styled.div`
 
 interface SettingsProps {
   readonly parameters: VapixParameters
-  readonly format?: Format
+  readonly api: string
   readonly onFormat: (format: Format) => void
   readonly onVapix: (key: string, value: string) => void
   readonly showStatsOverlay: boolean
@@ -51,13 +57,14 @@ interface SettingsProps {
 
 export const Settings: React.FC<SettingsProps> = ({
   parameters,
-  format,
+  api,
   onFormat,
   onVapix,
   showStatsOverlay,
   toggleStats,
 }) => {
   const [textString, setTextString] = useState(parameters['textstring'])
+  const [videoCodec] = useState(parameters['videocodec'])
   const textStringTimeout = useRef<number>()
 
   const changeParam: ChangeEventHandler<HTMLInputElement> = useCallback(
@@ -110,11 +117,21 @@ export const Settings: React.FC<SettingsProps> = ({
     [onVapix],
   )
 
+  const determinedFormat = useMemo(() => {
+    if (api === AXIS_IMAGE_CGI) {
+      return 'JPEG'
+    }
+
+    if (api === AXIS_MEDIA_AMP) {
+      return videoCodec === 'h264' ? 'H264' : 'MJPEG'
+    }
+  }, [api, videoCodec])
+
   return (
     <SettingsMenu>
       <SettingsItem>
         <div>Format</div>
-        <select onChange={changeFormat} defaultValue={format}>
+        <select onChange={changeFormat} defaultValue={determinedFormat}>
           <option value="H264">H.264 over RTP</option>
           <option value="MJPEG">JPEG over RTP</option>
           <option value="JPEG">Still image</option>

--- a/lib/WsRtspVideo.tsx
+++ b/lib/WsRtspVideo.tsx
@@ -100,16 +100,16 @@ export const WsRtspVideo: React.FC<WsRtspVideoProps> = ({
       return
     }
 
-    if (play && canplay && !playing) {
+    if (play && canplay === true && playing === false) {
       debugLog('play')
       videoEl.play().catch((err) => {
         console.error('VideoElement error: ', err.message)
       })
-    } else if (!play && playing) {
+    } else if (!play && playing === true) {
       debugLog('pause')
       videoEl.pause()
       unsetPlaying()
-    } else if (play && playing) {
+    } else if (play && playing === true) {
       if (__onPlayingRef.current !== undefined) {
         __onPlayingRef.current({
           el: videoEl,


### PR DESCRIPTION
BREAKING CHANGE:
Removes the `format` property from `Controls` and `Settings`.
Replaces it with `api` instead to properly determine which
format is in current use in the `Settings` menu.

Also fixes minor linting issues.

Fixes #79.