### PR TITLE
feat: BasicPlayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ React components for each format (currently RTP H.264 and JPEG, and still images
 ). The main video player will only handle the intended video state (attached to
 handlers) and format.
 
-You can either import the `Player` and use it directly (see the example
-application). If you want to build your own customized player, you can look at
+You can either import the `Player` or `BasicPlayer` and use them directly (see the example
+applications). If you want to build your own customized player, you can look at
 the latter component and build your own player, using the `Container`, `Layer`,
 and `PlaybackArea` components.
 
@@ -44,26 +44,27 @@ You can find an example of this under `examples/web-component`.
 
 Supported properties right now are:
 
-| Property              | Comment                                                                   |
-| --------------------- | ------------------------------------------------------------------------- |
-| `hostname`            | The ip address to your device                                             |
-| `autoplay`            | If the property exists, we try and autoplay your video                    |
-| `secure`              | If the property exists, we will connect with https instead of http        |
-| `format`              | Accepted values are `JPEG`, `MJPEG` or `H264`                             |
-| `compression`         | Accepted values are `0..100`, with 10 between each step                   |
-| `resolution`          | Written as WidthXHeight, eg `1920x1080`                                   |
-| `rotation`            | Accepted values are `0`, `90`, `180` and `270`                            |
-| `camera`              | Accepted values are `0...n` or `quad` depending on your device            |
-|                       | **H264 / MJPEG specific properties**                                      |
-| `fps`                 | Accepted values are `0...n`                                               |
-| `audio`               | Accepted values are `0` (off) and `1` (on)                                |
-| `clock`               | Accepted values are `0` (hide) and `1` (show)                             |
-| `date`                | Accepted values are `0` (hide) and `1` (show)                             |
-| `text`                | Accepted values are `0` (hide text overlay) and `1` (show text overlay)   |
-| `textstring`          | A percent-encoded string for the text overlay                             |
-| `textcolor`           | Accepted values are `black` and `white`                                   |
-| `textbackgroundcolor` | Accepted values are `black`, `white`, `transparent` and `semitransparent` |
-| `textpos`             | Accepted values are `0` (top) and `1` (bottom)                            |
+| Property              | Comment                                                                            |
+| --------------------- | ---------------------------------------------------------------------------------- |
+| `variant`             | Supported choices are `basic` or `advanced`. Refers to `BasicPlayer` and `Player`. |
+| `hostname`            | The ip address to your device                                                      |
+| `autoplay`            | If the property exists, we try and autoplay your video                             |
+| `secure`              | If the property exists, we will connect with https instead of http                 |
+| `format`              | Accepted values are `JPEG`, `MJPEG` or `H264`                                      |
+| `compression`         | Accepted values are `0..100`, with 10 between each step                            |
+| `resolution`          | Written as WidthXHeight, eg `1920x1080`                                            |
+| `rotation`            | Accepted values are `0`, `90`, `180` and `270`                                     |
+| `camera`              | Accepted values are `0...n` or `quad` depending on your device                     |
+|                       | **H264 / MJPEG specific properties**                                               |
+| `fps`                 | Accepted values are `0...n`                                                        |
+| `audio`               | Accepted values are `0` (off) and `1` (on)                                         |
+| `clock`               | Accepted values are `0` (hide) and `1` (show)                                      |
+| `date`                | Accepted values are `0` (hide) and `1` (show)                                      |
+| `text`                | Accepted values are `0` (hide text overlay) and `1` (show text overlay)            |
+| `textstring`          | A percent-encoded string for the text overlay                                      |
+| `textcolor`           | Accepted values are `black` and `white`                                            |
+| `textbackgroundcolor` | Accepted values are `black`, `white`, `transparent` and `semitransparent`          |
+| `textpos`             | Accepted values are `0` (top) and `1` (bottom)                                     |
 
 Example:
 

--- a/examples/react-app/App.jsx
+++ b/examples/react-app/App.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useCallback } from 'react'
 import styled, { createGlobalStyle } from 'styled-components'
 
-import { Player } from 'media-stream-player'
 import { SingleStream } from './SingleStream'
+import { BasicStream } from './BasicStream'
 import { MultiStream } from './MultiStream'
 
 const GlobalStyle = createGlobalStyle`
@@ -33,6 +33,11 @@ export const App = () => {
     localStorage.setItem(LOCALSTORAGE_KEY, 'single')
   }, [setState])
 
+  const basic = useCallback(() => {
+    setState('basic')
+    localStorage.setItem(LOCALSTORAGE_KEY, 'basic')
+  }, [setState])
+
   const multi = useCallback(() => {
     setState('multi')
     localStorage.setItem(LOCALSTORAGE_KEY, 'multi')
@@ -43,9 +48,11 @@ export const App = () => {
       <GlobalStyle />
       <ButtonContainer>
         <Button onClick={single}>Single stream example</Button>
+        <Button onClick={basic}>Basic stream example</Button>
         <Button onClick={multi}>Multi stream example</Button>
       </ButtonContainer>
       {state === 'single' ? <SingleStream /> : null}
+      {state === 'basic' ? <BasicStream /> : null}
       {state === 'multi' ? <MultiStream /> : null}
     </>
   )

--- a/examples/react-app/BasicStream.jsx
+++ b/examples/react-app/BasicStream.jsx
@@ -1,0 +1,89 @@
+import React, { useState, useCallback } from 'react'
+import styled from 'styled-components'
+
+import { BasicPlayer } from 'media-stream-player'
+
+const AppContainer = styled.div`
+  width: 100vw;
+  height: 90vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`
+
+const HostnameContainer = styled.div`
+  align-items: center;
+  display: inline-grid;
+  grid-gap: 10px;
+  grid-template-columns: auto 1fr auto;
+  padding: 10px 0;
+`
+
+const MediaPlayer = styled(BasicPlayer)`
+  width: 100%;
+  height: 100%;
+`
+
+const DEFAULT_HOSTNAME = '192.168.0.90'
+
+// force auth
+const authorize = async (host) => {
+  // Force a login by fetching usergroup
+  try {
+    await window.fetch(`http://${host}/axis-cgi/usergroup.cgi`, {
+      credentials: 'include',
+      mode: 'no-cors',
+    })
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+/**
+ * Example application that uses the `Player` component.
+ */
+
+export const BasicStream = () => {
+  const [state, setState] = useState({
+    authorized: false,
+    hostname: localStorage.getItem('hostname') || DEFAULT_HOSTNAME,
+  })
+
+  const connect = useCallback(() => {
+    if (!state.authorized) {
+      authorize(state.hostname).then(() => {
+        setState({ ...state, authorized: true })
+      })
+    }
+  }, [state.authorized, state.hostname])
+
+  return (
+    <>
+      <AppContainer>
+        <h1>basic stream media-stream-player</h1>
+        <HostnameContainer>
+          <label htmlFor="hostname">Hostname</label>
+          <input
+            id="hostname"
+            value={state.hostname}
+            onChange={({ target: { value } }) => {
+              setState({ authorized: false, hostname: value })
+              localStorage.setItem('hostname', value)
+            }}
+          />
+          <button onClick={connect}>connect</button>
+        </HostnameContainer>
+        {state.authorized ? (
+          <MediaPlayer
+            hostname={state.hostname}
+            format="H264"
+            autoPlay
+            vapixParams={{ resolution: '800x600' }}
+          />
+        ) : (
+          <div>Not authorized</div>
+        )}
+      </AppContainer>
+    </>
+  )
+}

--- a/lib/BasicPlayer.tsx
+++ b/lib/BasicPlayer.tsx
@@ -1,0 +1,206 @@
+import React, {
+  useState,
+  forwardRef,
+  useEffect,
+  useCallback,
+  useMemo,
+  useLayoutEffect,
+  useRef,
+} from 'react'
+
+import { Container, Layer } from './Container'
+import {
+  PlaybackArea,
+  AXIS_MEDIA_AMP,
+  AXIS_IMAGE_CGI,
+  VapixParameters,
+  VideoProperties,
+} from './PlaybackArea'
+import { ControlArea, ControlBar } from './Controls'
+import { Button } from './components/Button'
+import { Pause, Play } from './img'
+import { useUserActive } from './hooks/useUserActive'
+import { Format, PlayerNativeElement } from './utils'
+import { MediaStreamPlayerContainer } from './components/MediaStreamPlayerContainer'
+import { Limiter } from './components/Limiter'
+
+const DEFAULT_API_TYPE = AXIS_IMAGE_CGI
+
+interface BasicPlayerProps {
+  readonly hostname: string
+  readonly vapixParams?: VapixParameters
+  readonly format?: Format
+  readonly autoPlay?: boolean
+  /**
+   * Set to true if the camera requires a secure
+   * connection, "https" and "wss" protocols.
+   */
+  readonly secure?: boolean
+  readonly className?: string
+}
+
+export const BasicPlayer = forwardRef<PlayerNativeElement, BasicPlayerProps>(
+  (
+    { hostname, vapixParams = {}, format, autoPlay = false, secure, className },
+    ref,
+  ) => {
+    const [play, setPlay] = useState(autoPlay)
+    const [refresh, setRefresh] = useState(0)
+    const [host, setHost] = useState(hostname)
+    const [api, setApi] = useState<string>(DEFAULT_API_TYPE)
+
+    /**
+     * VAPIX parameters
+     */
+    const [parameters, setParameters] = useState(vapixParams)
+
+    /**
+     * Controls
+     */
+    const [videoProperties, setVideoProperties] = useState<VideoProperties>()
+
+    const onPlaying = useCallback(
+      (props: VideoProperties) => {
+        setVideoProperties(props)
+      },
+      [setVideoProperties],
+    )
+
+    const onPlayPause = useCallback(() => {
+      if (play) {
+        setPlay(false)
+      } else {
+        setHost(hostname)
+        setPlay(true)
+      }
+    }, [play, hostname])
+
+    const onFormat = useCallback((newFormat: Format | undefined) => {
+      switch (newFormat) {
+        case 'H264':
+          setApi(AXIS_MEDIA_AMP)
+          setParameters((prevParams) => ({ ...prevParams, videocodec: 'h264' }))
+          break
+        case 'MJPEG':
+          setApi(AXIS_MEDIA_AMP)
+          setParameters((prevParams) => ({ ...prevParams, videocodec: 'jpeg' }))
+          break
+        case 'JPEG':
+        default:
+          setApi(AXIS_IMAGE_CGI)
+          break
+      }
+      setRefresh((value) => value + 1)
+    }, [])
+
+    useEffect(() => {
+      onFormat(format)
+    }, [format, onFormat])
+
+    useEffect(() => {
+      const cb = () => {
+        if (document.visibilityState === 'visible') {
+          setPlay(true)
+          setHost(hostname)
+        } else if (document.visibilityState === 'hidden') {
+          setPlay(false)
+          setHost('')
+        }
+      }
+
+      document.addEventListener('visibilitychange', cb)
+
+      return () => document.removeEventListener('visibilitychange', cb)
+    }, [hostname])
+
+    /**
+     * Aspect ratio
+     *
+     * This needs to be set so make the Container (and Layers) match the size of
+     * the visible image of the video or still image.
+     */
+
+    const naturalAspectRatio = useMemo(() => {
+      if (videoProperties === undefined) {
+        return undefined
+      }
+
+      const { width, height } = videoProperties
+
+      return width / height
+    }, [videoProperties])
+
+    /**
+     * Limit video size.
+     *
+     * The video size should not expand outside the available container, and
+     * should be recomputed on resize.
+     */
+
+    const limiterRef = useRef<HTMLDivElement>(null)
+    useLayoutEffect(() => {
+      if (naturalAspectRatio === undefined || limiterRef.current === null) {
+        return
+      }
+
+      const observer = new window.ResizeObserver(([entry]) => {
+        const element = entry.target as HTMLElement
+        const maxWidth = element.clientHeight * naturalAspectRatio
+        element.style.maxWidth = `${maxWidth}px`
+      })
+      observer.observe(limiterRef.current)
+
+      return () => observer.disconnect()
+    }, [naturalAspectRatio])
+
+    const controlArea = useRef(null)
+    const userActive = useUserActive(controlArea)
+
+    /**
+     * Render
+     *
+     * Each layer is positioned exactly on top of the visible image, since the
+     * aspect ratio is carried over to the container, and the layers match the
+     * container size.
+     */
+
+    return (
+      <MediaStreamPlayerContainer className={className}>
+        <Limiter ref={limiterRef}>
+          <Container aspectRatio={naturalAspectRatio}>
+            <Layer>
+              <PlaybackArea
+                forwardedRef={ref}
+                refresh={refresh}
+                play={play}
+                host={host}
+                api={api}
+                parameters={parameters}
+                onPlaying={onPlaying}
+                secure={secure}
+              />
+            </Layer>
+            <Layer>
+              <ControlArea
+                ref={controlArea}
+                visible={play !== true || userActive}
+              >
+                <ControlBar>
+                  <Button onClick={onPlayPause}>
+                    {play === true ? (
+                      <Pause title="Pause" />
+                    ) : (
+                      <Play title="Play" />
+                    )}
+                  </Button>
+                </ControlBar>
+              </ControlArea>
+            </Layer>
+          </Container>
+        </Limiter>
+      </MediaStreamPlayerContainer>
+    )
+  },
+)
+
+BasicPlayer.displayName = 'BasicPlayer'

--- a/lib/Controls.tsx
+++ b/lib/Controls.tsx
@@ -4,12 +4,12 @@ import styled from 'styled-components'
 import { useUserActive } from './hooks/useUserActive'
 
 import { Button } from './components/Button'
-import { Format } from './Player'
 import { Play, Pause, Stop, Refresh, CogWheel, Screenshot } from './img'
 import { Settings } from './Settings'
 import { VapixParameters } from './PlaybackArea'
+import { Format } from './utils'
 
-const ControlArea = styled.div<{ readonly visible: boolean }>`
+export const ControlArea = styled.div<{ readonly visible: boolean }>`
   width: 100%;
   height: 100%;
   display: flex;
@@ -19,7 +19,7 @@ const ControlArea = styled.div<{ readonly visible: boolean }>`
   transition: opacity 0.3s ease-in-out;
 `
 
-const ControlBar = styled.div`
+export const ControlBar = styled.div`
   width: 100%;
   height: 32px;
   background: rgb(0, 0, 0, 0.66);

--- a/lib/MediaStreamPlayer.tsx
+++ b/lib/MediaStreamPlayer.tsx
@@ -1,9 +1,16 @@
 import React, { useState, useEffect, useMemo } from 'react'
 import ReactDOM from 'react-dom'
+import { BasicPlayer } from './BasicPlayer'
 import { VapixParameters } from './PlaybackArea'
-import { Format, Player } from './Player'
+import { Player } from './Player'
+import { Format } from './utils/common'
 
+enum PlayerVariants {
+  BASIC = 'basic',
+  ADVANCED = 'advanced',
+}
 interface InitialAttributes {
+  readonly variant: string
   readonly hostname: string
   readonly autoplay: boolean
   readonly format: string
@@ -39,6 +46,7 @@ export class MediaStreamPlayer extends HTMLElement {
 
   public static get observedAttributes() {
     return [
+      'variant',
       'hostname',
       'autoplay',
       'format',
@@ -61,6 +69,7 @@ export class MediaStreamPlayer extends HTMLElement {
 
   private get allAttributes() {
     const {
+      variant,
       hostname,
       autoplay,
       format,
@@ -81,6 +90,7 @@ export class MediaStreamPlayer extends HTMLElement {
     } = this
 
     return {
+      variant,
       hostname,
       autoplay,
       format,
@@ -99,6 +109,14 @@ export class MediaStreamPlayer extends HTMLElement {
       textpos,
       secure,
     }
+  }
+
+  public get variant() {
+    return this.getAttribute('variant') ?? PlayerVariants.ADVANCED
+  }
+
+  public set variant(value: string) {
+    this.setAttribute('variant', value)
   }
 
   public get hostname() {
@@ -307,6 +325,7 @@ const PlayerComponent: React.FC<PlayerComponentProps> = ({
   }, [subscribeAttributesChanged])
 
   const {
+    variant,
     hostname,
     autoplay,
     format,
@@ -364,13 +383,29 @@ const PlayerComponent: React.FC<PlayerComponentProps> = ({
     textpos,
   ])
 
-  return (
-    <Player
-      hostname={hostname}
-      autoPlay={autoplay}
-      format={format as Format}
-      vapixParams={vapixParameters}
-      secure={secure}
-    />
-  )
+  switch (variant) {
+    case PlayerVariants.ADVANCED:
+      return (
+        <Player
+          hostname={hostname}
+          autoPlay={autoplay}
+          format={format as Format}
+          vapixParams={vapixParameters}
+          secure={secure}
+        />
+      )
+    case PlayerVariants.BASIC:
+      return (
+        <BasicPlayer
+          hostname={hostname}
+          autoPlay={autoplay}
+          format={format as Format}
+          vapixParams={vapixParameters}
+          secure={secure}
+        />
+      )
+    default:
+      console.error('No player variant selected')
+      return null
+  }
 }

--- a/lib/PlaybackArea.tsx
+++ b/lib/PlaybackArea.tsx
@@ -2,11 +2,11 @@ import React, { Ref } from 'react'
 import { Sdp, pipelines } from 'media-stream-library/dist/esm/index.browser'
 import debug from 'debug'
 
-import { PlayerNativeElement } from './Player'
 import { WsRtspVideo } from './WsRtspVideo'
 import { WsRtspCanvas } from './WsRtspCanvas'
 import { StillImage } from './StillImage'
 import { MetadataHandler } from './metadata'
+import { PlayerNativeElement } from './utils/common'
 
 const debugLog = debug('msp:api')
 

--- a/lib/Player.tsx
+++ b/lib/Player.tsx
@@ -7,7 +7,6 @@ import React, {
   useLayoutEffect,
   useRef,
 } from 'react'
-import styled from 'styled-components'
 import { Sdp } from 'media-stream-library/dist/esm/utils/protocols'
 
 import { Container, Layer } from './Container'
@@ -22,38 +21,12 @@ import { Controls } from './Controls'
 import { Feedback } from './Feedback'
 import { Stats } from './Stats'
 import { useSwitch } from './hooks/useSwitch'
-import { getImageURL } from './utils'
+import { getImageURL, Format, PlayerNativeElement } from './utils'
 import { MetadataHandler } from './metadata'
+import { Limiter } from './components/Limiter'
+import { MediaStreamPlayerContainer } from './components/MediaStreamPlayerContainer'
 
 const DEFAULT_API_TYPE = AXIS_IMAGE_CGI
-
-/**
- * Wrapper for the entire player that will take up all available place from the
- * parent.
- */
-const MediaStreamPlayerContainer = styled.div`
-  position: relative;
-  width: 100%;
-  height: 100%;
-`
-
-/**
- * The limiter prevents the video element to use up all of the available width.
- * The player container will automatically limit it's own height based on the
- * available width (keeping aspect ratio).
- */
-const Limiter = styled.div`
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 100%;
-  top: 0;
-  bottom: 0;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-`
 
 interface PlayerProps {
   readonly hostname: string
@@ -69,19 +42,6 @@ interface PlayerProps {
   readonly secure?: boolean
   readonly aspectRatio?: number
   readonly className?: string
-}
-
-export type PlayerNativeElement =
-  | HTMLVideoElement
-  | HTMLCanvasElement
-  | HTMLImageElement
-
-export type Format = 'H264' | 'MJPEG' | 'JPEG'
-
-export const FORMAT_API = {
-  H264: AXIS_MEDIA_AMP,
-  MJPEG: AXIS_MEDIA_AMP,
-  JPEG: AXIS_IMAGE_CGI,
 }
 
 export const Player = forwardRef<PlayerNativeElement, PlayerProps>(

--- a/lib/Settings.tsx
+++ b/lib/Settings.tsx
@@ -7,9 +7,9 @@ import React, {
 } from 'react'
 import styled from 'styled-components'
 
-import { Format } from './Player'
 import { AXIS_IMAGE_CGI, AXIS_MEDIA_AMP, VapixParameters } from './PlaybackArea'
 import { Switch } from './components/Switch'
+import { Format } from './utils'
 
 const SettingsMenu = styled.div`
   font-family: sans-serif;

--- a/lib/components/Limiter.tsx
+++ b/lib/components/Limiter.tsx
@@ -1,0 +1,19 @@
+import styled from 'styled-components'
+
+/**
+ * The limiter prevents the video element to use up all of the available width.
+ * The player container will automatically limit it's own height based on the
+ * available width (keeping aspect ratio).
+ */
+export const Limiter = styled.div`
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`

--- a/lib/components/MediaStreamPlayerContainer.tsx
+++ b/lib/components/MediaStreamPlayerContainer.tsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components'
+
+/**
+ * Wrapper for the entire player that will take up all available place from the
+ * parent.
+ */
+export const MediaStreamPlayerContainer = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100%;
+`

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,7 @@
 import { MediaStreamPlayer } from './MediaStreamPlayer'
 
 export * from './Player'
+export * from './BasicPlayer'
 export * from './Container'
 export * from './PlaybackArea'
 export * from './Stats'

--- a/lib/utils/common.ts
+++ b/lib/utils/common.ts
@@ -1,0 +1,14 @@
+import { AXIS_MEDIA_AMP, AXIS_IMAGE_CGI } from '..'
+
+export type PlayerNativeElement =
+  | HTMLVideoElement
+  | HTMLCanvasElement
+  | HTMLImageElement
+
+export type Format = 'H264' | 'MJPEG' | 'JPEG'
+
+export const FORMAT_API = {
+  H264: AXIS_MEDIA_AMP,
+  MJPEG: AXIS_MEDIA_AMP,
+  JPEG: AXIS_IMAGE_CGI,
+}

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './GetImageURL'
+export * from './common'


### PR DESCRIPTION
Added the `BasicPlayer` component. This is an attempt to create the "bare minimum" component that you need to play a stream from an AXIS camera.

Refactored the code a bit so there would be less code duplication between `Player` and `BasicPlayer`. Also gave the user of the web component the choice between `basic` and `advanced` which of course refers to the `BasicPlayer` and `Player` respectively.