### PR TITLE
feat: extra target for older browsers

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,0 +1,19 @@
+{
+  "sourceType": "unambiguous",
+  "presets": [
+    "@babel/typescript",
+    "@babel/preset-react",
+    [
+      "@babel/env",
+      {
+        "targets": { "browsers": ["last 2 versions, not dead"] },
+        "useBuiltIns": "usage",
+        "corejs": { "version": "3.8", "proposals": true }
+      }
+    ]
+  ],
+  "plugins": [
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-proposal-object-rest-spread"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.3.0",
   "description": "Player built on top of media-stream-library",
   "license": "MIT",
-  "main": "dist/esm/index.js",
+  "main": "dist/es5/index.js",
   "types": "dist/esm/index.d.ts",
   "scripts": {
     "lint": "yarn lint:ts && yarn prettier:check",
@@ -16,9 +16,10 @@
     "dev:esm": "yarn tsc --watch",
     "dev:example": "webpack serve --config webpack.example.js --env camera=$MSP_CAMERA",
     "dev": "yarn build:esm && concurrently \"yarn dev:esm\" \"yarn dev:example\"",
+    "build:es5": "yarn babel --extensions '.ts,.tsx' -d dist/es5 lib",
     "build:esm": "yarn tsc",
     "build:bundle": "yarn webpack --config webpack.config.js && sbin/copyMinified.sh",
-    "build": "yarn build:esm && yarn build:bundle",
+    "build": "yarn build:es5 && yarn build:esm && yarn build:bundle",
     "release": "sbin/release.sh"
   },
   "repository": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,26 +21,6 @@ module.exports = {
         test: /\.tsx?$/,
         use: {
           loader: 'babel-loader',
-          options: {
-            babelrc: false,
-            sourceType: 'unambiguous',
-            presets: [
-              '@babel/typescript',
-              '@babel/preset-react',
-              [
-                '@babel/env',
-                {
-                  targets: { browsers: ['last 2 versions, not dead'] },
-                  useBuiltIns: 'usage',
-                  corejs: { version: '3.8', proposals: true },
-                },
-              ],
-            ],
-            plugins: [
-              '@babel/plugin-proposal-class-properties',
-              '@babel/plugin-proposal-object-rest-spread',
-            ],
-          },
         },
       },
     ],

--- a/webpack.example.js
+++ b/webpack.example.js
@@ -28,26 +28,6 @@ module.exports = (env) => {
           test: /\.jsx?$/,
           use: {
             loader: 'babel-loader',
-            options: {
-              babelrc: false,
-              presets: [
-                '@babel/preset-react',
-                [
-                  '@babel/env',
-                  {
-                    targets: {
-                      browsers: [
-                        'last 2 chrome versions, last 2 firefox versions',
-                      ],
-                    },
-                  },
-                ],
-              ],
-              plugins: [
-                '@babel/plugin-proposal-class-properties',
-                '@babel/plugin-proposal-object-rest-spread',
-              ],
-            },
           },
         },
       ],


### PR DESCRIPTION
Alternative solution for module entry point with browserslist.
What about core-js dependencies, does this need to be specified
in the package.json file?