### PR TITLE
feat: add SDP support for WsRtspCanvas

### DIFF
--- a/lib/PlaybackArea.tsx
+++ b/lib/PlaybackArea.tsx
@@ -277,7 +277,7 @@ export const PlaybackArea: React.FC<PlaybackAreaProps> = ({
       <WsRtspCanvas
         key={refresh}
         forwardedRef={forwardedRef as Ref<HTMLCanvasElement>}
-        {...{ ws, rtsp, play, offset, onPlaying }}
+        {...{ ws, rtsp, play, offset, onPlaying, onSdp }}
       />
     )
   }

--- a/lib/WsRtspVideo.tsx
+++ b/lib/WsRtspVideo.tsx
@@ -49,6 +49,9 @@ interface WsRtspVideoProps {
    * Callback to signal video is playing.
    */
   readonly onPlaying?: (videoProperties: VideoProperties) => void
+  /**
+   * Callback when SDP data is received.
+   */
   readonly onSdp?: (msg: Sdp) => void
   readonly metadataHandler?: MetadataHandler
   /**


### PR DESCRIPTION
This previously only existed on WsRtspVideo, but as this is available
for WsRtspCanvas as well we should expose it so the data can be used as
well if needed.