### PR TITLE
chore: use range for `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,10 +41,10 @@
     "react-hooks-shareable": "1.27.0"
   },
   "peerDependencies": {
-    "luxon": "1.25.0",
-    "react": "17.0.1",
-    "react-dom": "17.0.1",
-    "styled-components": "5.2.0"
+    "luxon": "^1.25.0",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
+    "styled-components": "^5.2.0"
   },
   "devDependencies": {
     "@babel/cli": "7.14.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9744,10 +9744,10 @@ fsevents@~2.3.1:
     webpack-cli: 4.7.0
     webpack-dev-server: 3.11.2
   peerDependencies:
-    luxon: 1.25.0
-    react: 17.0.1
-    react-dom: 17.0.1
-    styled-components: 5.2.0
+    luxon: ^1.25.0
+    react: ^17.0.1
+    react-dom: ^17.0.1
+    styled-components: ^5.2.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Currently if the repository that uses this library does not have the same version of the peer dependency a warning is shown during the installation of the packages. This change updates `peerDependencies` to use a range.

An example of the warning with the current version of the library:

```
<package> provides luxon (p6d2ed) with version 1.26.0, which doesn't satisfy what media-stream-player requests
```