### PR TITLE
chore: update node versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v1
         with:
-          node-version: '14'
+          node-version: '16'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['14', '15']
+        node-version: ['16', '18']
     steps:
       - uses: actions/checkout@v1
       - name: Setup node


### PR DESCRIPTION
### Describe your changes

Update node versions, use 16 as stable and 18 as next.
