### PR TITLE
feat!: add expanded prop to stats overlay

### DIFF
--- a/lib/Player.tsx
+++ b/lib/Player.tsx
@@ -109,6 +109,7 @@ export const Player = forwardRef<PlayerNativeElement, PlayerProps>(
         ? window.localStorage.getItem('stats-overlay') === 'on'
         : false,
     )
+    const [statsExpanded, setStatsExpanded] = useState(true)
 
     useEffect(() => {
       if (window?.localStorage !== undefined) {
@@ -334,6 +335,8 @@ export const Player = forwardRef<PlayerNativeElement, PlayerProps>(
                 videoProperties={videoProperties}
                 refresh={refresh}
                 volume={volume}
+                expanded={statsExpanded}
+                onToggleExpanded={setStatsExpanded}
               />
             ) : null}
           </Container>

--- a/lib/Stats.tsx
+++ b/lib/Stats.tsx
@@ -117,6 +117,8 @@ interface StatsProps {
   readonly videoProperties: VideoProperties
   readonly refresh: number
   readonly volume?: number
+  readonly expanded: boolean
+  readonly onToggleExpanded: (value: boolean) => void
 }
 
 interface Stat {
@@ -125,12 +127,9 @@ interface Stat {
   readonly unit?: string
 }
 
-const StatsData: React.FC<StatsProps> = ({
-  format,
-  videoProperties,
-  refresh,
-  volume,
-}) => {
+const StatsData: React.FC<
+  Omit<StatsProps, 'expanded' | 'onToggleExpanded'>
+> = ({ format, videoProperties, refresh, volume }) => {
   const [stats, setStats] = useState<Array<Stat>>([])
 
   // Updates stat values
@@ -232,21 +231,21 @@ export const Stats: React.FC<StatsProps> = ({
   videoProperties,
   refresh,
   volume,
+  expanded,
+  onToggleExpanded,
 }) => {
-  const [showStats, setShowStats] = useState(true)
-
   // Handles show/hide stats
   const onToggleStats = useCallback<MouseEventHandler<HTMLAnchorElement>>(
     (e) => {
       e.preventDefault()
-      setShowStats((prevState) => !prevState)
+      onToggleExpanded(!expanded)
     },
-    [setShowStats],
+    [expanded, onToggleExpanded],
   )
 
   return (
     <>
-      {showStats ? (
+      {expanded ? (
         <StatsWrapper>
           <StatsHeader>
             <StatsIcon clickable={false}>


### PR DESCRIPTION
### Describe your changes

Stat overlay expanded state can now be
toggled by its parent component.

### Issue ticket number and link

- Fixes #211 

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation

![statsoverlay](https://user-images.githubusercontent.com/77433590/171631070-4c016851-35ad-4fdf-bec7-7074f6044a65.gif)

